### PR TITLE
Slight changes to the table widget parameters.

### DIFF
--- a/CanadianWebServices/canadian_web_services.py
+++ b/CanadianWebServices/canadian_web_services.py
@@ -449,7 +449,7 @@ class CanadianWebServices(object):
 		self.dlg.tableWidget.setColumnWidth(1, 110)
 		self.dlg.tableWidget.setColumnWidth(2, 158)
 		self.dlg.tableWidget.setColumnWidth(3, 60)
-		self.dlg.tableWidget.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+		self.dlg.tableWidget.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
 		self.dlg.tableWidget.verticalHeader().setSectionResizeMode(QHeaderView.Fixed)
 		
 		#self.dlg.tableWidget.resizeRowsToContents()

--- a/CanadianWebServices/canadian_web_services.py
+++ b/CanadianWebServices/canadian_web_services.py
@@ -231,7 +231,9 @@ class CanadianWebServices(object):
 		self.services = self.loadServiceList()
 		if self.works == True: # only sorts when the url worked
 			self.services = self.sortServices(self.services) # initialize and sort the services
-			self.shownServices = self.services # will change when serch criteria change to allow for the selected dataset to be found by row number		
+			self.shownServices = self.services # will change when serch criteria change to allow for the selected dataset to be found by row number	
+		#enlable hidpi scaling
+		QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
 	# noinspection PyMethodMayBeStatic
 	def tr(self, message):

--- a/CanadianWebServices/canadian_web_services.py
+++ b/CanadianWebServices/canadian_web_services.py
@@ -445,12 +445,11 @@ class CanadianWebServices(object):
 	# setTableWidgetBehaviour(self) defines how tableWidget will behave
 	# setTableWidgetBehaviour: CWS -> None
 	def setTableWidgetBehaviour(self):
-		# set row and column sizes and lock them
-		self.dlg.tableWidget.setColumnWidth(0, 110)
+		self.dlg.tableWidget.setColumnWidth(0, 185)
 		self.dlg.tableWidget.setColumnWidth(1, 110)
-		self.dlg.tableWidget.setColumnWidth(2, 207)
-		self.dlg.tableWidget.setColumnWidth(3, 86)
-		self.dlg.tableWidget.horizontalHeader().setSectionResizeMode(QHeaderView.Fixed)
+		self.dlg.tableWidget.setColumnWidth(2, 158)
+		self.dlg.tableWidget.setColumnWidth(3, 60)
+		self.dlg.tableWidget.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
 		self.dlg.tableWidget.verticalHeader().setSectionResizeMode(QHeaderView.Fixed)
 		
 		#self.dlg.tableWidget.resizeRowsToContents()


### PR DESCRIPTION
This is a follow up to help improve usability of the interface.

The Name column is too small whereas the last two columns have some dead space, so in order to fix this this PR changes the default size and allows the user to change the size of the columns.

@eswright I'm not sure why things were fixed in the first place but I think this will improve usability and readability.